### PR TITLE
Add migration code of cloud_service_tag in v1.10.4

### DIFF
--- a/src/migration/v1_10_4.py
+++ b/src/migration/v1_10_4.py
@@ -1,0 +1,25 @@
+import logging
+from conf import DEFAULT_LOGGER
+from pymongo import UpdateOne, DeleteOne
+from lib import MongoCustomClient
+from lib.util import query
+
+_LOGGER = logging.getLogger(DEFAULT_LOGGER)
+
+
+@query
+def inventory_cloud_service_tag_delete_project_id(mongo_client: MongoCustomClient):
+    items = mongo_client.find('INVENTORY', 'cloud_service_tag', {}, {'project_id': 1})
+
+    operations = []
+    for item in items:
+        operations.append(
+            UpdateOne({'_id': item['_id']}, {"$unset": {"project_id": ""}})
+        )
+    mongo_client.bulk_write('INVENTORY', 'cloud_service_tag', operations)
+
+
+def main(file_path, debug):
+    mongo_client: MongoCustomClient = MongoCustomClient(file_path, debug)
+
+    inventory_cloud_service_tag_delete_project_id(mongo_client)


### PR DESCRIPTION
Signed-off-by: Seolmin Kwon <seolmin@megazone.com>

### Category
- [x] New feature
- [ ] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
add migration code of cloud_service_tag in v1.10.4
* I wrote code to remove project_id field from cloud_service_tag collection in inventory database.
